### PR TITLE
used hexadecimal endoding for accountId in accountCert

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,15 @@
       <option name="name" value="JBoss Community repository" />
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="central" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="github" />
+      <option name="name" value="github" />
+      <option name="url" value="https://maven.pkg.github.com/ADORSYS-GIS/webank-BankAccount" />
+    </remote-repository>
   </component>
 </project>

--- a/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
@@ -69,7 +69,7 @@ public class BankAccountCertificateCreationServiceImpl implements BankAccountCer
 
             // Compute hash of the account ID
             byte[] hashedAccountId = digest.digest(accountId.getBytes(StandardCharsets.UTF_8));
-            String accountIdHash = Base64.getEncoder().encodeToString(hashedAccountId);
+            String accountIdHash = HashUtil.hashToHex(hashedAccountId);
 
             // Calculate expiration timestamp
             long expirationTime = Instant.now().plusSeconds(EXPIRATION_DAYS * 86400).getEpochSecond();
@@ -95,6 +95,17 @@ public class BankAccountCertificateCreationServiceImpl implements BankAccountCer
             // Log the exception for debugging
             log.error("Error generating device certificate", e);
             throw new IllegalStateException("Error generating device certificate");
+        }
+    }
+
+    public static class HashUtil {
+        public static String hashToHex(byte[] hashedBytes) {
+            // Convert to Hex encoding
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashedBytes) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
         }
     }
 }

--- a/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
@@ -32,7 +32,7 @@ public class BankAccountCertificateCreationServiceImpl implements BankAccountCer
     private String serverPublicKeyJson;
 
     @Autowired
-    public BankAccountCertificateCreationServiceImpl(BankAccountService bankAccountService) {
+    private BankAccountCertificateCreationServiceImpl(BankAccountService bankAccountService) {
         this.bankAccountService = bankAccountService;
     }
 

--- a/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
@@ -99,6 +99,12 @@ public class BankAccountCertificateCreationServiceImpl implements BankAccountCer
     }
 
     public static class HashUtil {
+
+        //Private constructor to prevent instantiation
+        private HashUtil() {
+
+        }
+
         public static String hashToHex(byte[] hashedBytes) {
             // Convert to Hex encoding
             StringBuilder hexString = new StringBuilder();

--- a/webank-bank-account/webank-bank-account-service-impl/src/test/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImplTest.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/test/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImplTest.java
@@ -102,9 +102,11 @@ class BankAccountCertificateCreationServiceImplTest {
 
         // Validate account ID hash
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+        // Compute hash of the account ID
         byte[] hashedAccountId = digest.digest(accountId.getBytes(StandardCharsets.UTF_8));
-        String expectedAccHash = Base64.getEncoder().encodeToString(hashedAccountId);
-        assertEquals(expectedAccHash, claims.getStringClaim("acc"));
+        String expectedAccountIdHash = BankAccountCertificateCreationServiceImpl.HashUtil.hashToHex(hashedAccountId);
+        assertEquals(expectedAccountIdHash, claims.getStringClaim("acc"));
 
         // Validate device public key hash
         byte[] hashedDeviceKey = digest.digest(devicePublicKey.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
**Description**

- Implement HashUtil for accountId hashing and ensure frontend compatibility
- Use HashUtil for accountId hashing to meet frontend comparison requirements
