### PR TITLE
Align server key property names with shared middleware standard

### DIFF
--- a/webank-bank-account/webank-bank-account-rest-server/src/test/resources/application.properties
+++ b/webank-bank-account/webank-bank-account-rest-server/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 # Server private key in JWK format
-server.private.key=${SERVER_PRIVATE_KEY_JSON}
-
+server.privateKey=${SERVER_PRIVATE_KEY_JSON}
 # Server public key in JWK format
-server.public.key=${SERVER_PUBLIC_KEY_JSON}
+server.publicKey=${SERVER_PUBLIC_KEY_JSON}

--- a/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/main/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImpl.java
@@ -25,11 +25,8 @@ public class BankAccountCertificateCreationServiceImpl implements BankAccountCer
     private static  final long EXPIRATION_DAYS = 30;
     private final BankAccountService bankAccountService;
 
-    @Value("${server.private.key}")
+    @Value("${server.privateKey}")
     private String serverPrivateKeyJson;
-
-    @Value("${server.public.key}")
-    private String serverPublicKeyJson;
 
     @Autowired
     private BankAccountCertificateCreationServiceImpl(BankAccountService bankAccountService) {

--- a/webank-bank-account/webank-bank-account-service-impl/src/main/resources/application.properties
+++ b/webank-bank-account/webank-bank-account-service-impl/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 # Server private key in JWK format
-server.private.key=${SERVER_PRIVATE_KEY_JSON}
-
+server.privateKey=${SERVER_PRIVATE_KEY_JSON}
 # Server public key in JWK format
-server.public.key=${SERVER_PUBLIC_KEY_JSON}
+server.publicKey=${SERVER_PUBLIC_KEY_JSON}

--- a/webank-bank-account/webank-bank-account-service-impl/src/test/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImplTest.java
+++ b/webank-bank-account/webank-bank-account-service-impl/src/test/java/de/adorsys/webank/bank/api/service/impl/BankAccountCertificateCreationServiceImplTest.java
@@ -47,7 +47,6 @@ class BankAccountCertificateCreationServiceImplTest {
 
         // Inject the server's private and public keys into the service
         ReflectionTestUtils.setField(service, "serverPrivateKeyJson", ecKey.toJSONString());
-        ReflectionTestUtils.setField(service, "serverPublicKeyJson", ecKey.toPublicJWK().toJSONString());
     }
 
     @Test

--- a/webank-bank-account/webank-bank-account-service-impl/src/test/resources/application.properties
+++ b/webank-bank-account/webank-bank-account-service-impl/src/test/resources/application.properties
@@ -10,9 +10,9 @@ spring.datasource.password=sa
 
 spring.jpa.hibernate.ddl-auto=create-drop
 # Server private key in JWK format
-server.private.key=${SERVER_PRIVATE_KEY_JSON}
 
+server.privateKey=${SERVER_PRIVATE_KEY_JSON}
 # Server public key in JWK format
-server.public.key=${SERVER_PUBLIC_KEY_JSON}
+server.publicKey=${SERVER_PUBLIC_KEY_JSON}
 
 logging.level.org.hibernate=WARN


### PR DESCRIPTION
### Description
- Updated property names and references in configuration and service classes to align with standardized naming conventions across services.
- Renamed server.private.key and server.public.key properties to server.privateKey and server.publicKey.
- Updated Spring value injection accordingly in implementation classes.
- Removed unused imports and updated test resources for consistency.
- Prepares the service for consistent integration with shared JWT validation middleware from PRS. 
